### PR TITLE
ci: grant write permissions to bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
`peter-evans/create-pull-request` needs `contents: write` and `pull-requests: write` to push branches and open PRs. Without these, the job gets a 403 from GitHub.

Fixes https://github.com/HayatoYagi/ktor-typed-endpoint/actions/runs/23504738596/job/68409317330

🤖 Generated with [Claude Code](https://claude.com/claude-code)