### PR TITLE
feat: add ktor-client and ktor-client-ksp modules for type-safe client codegen

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: 'temurin'
       - uses: gradle/actions/setup-gradle@v4
       - name: Publish
-        run: ./gradlew :core:publishAllPublicationsToMavenCentralRepository :ktor-server:publishAllPublicationsToMavenCentralRepository
+        run: ./gradlew :core:publishAllPublicationsToMavenCentralRepository :ktor-server:publishAllPublicationsToMavenCentralRepository :ktor-client:publishAllPublicationsToMavenCentralRepository :ktor-client-ksp:publishAllPublicationsToMavenCentralRepository
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Type-safe HTTP endpoint contracts for Ktor — bind routing, request/response ty
 - [Motivation](#motivation)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
+  - [Server](#server)
+  - [Client (KSP)](#client-ksp)
 - [Features](#features)
   - [@ApiTag — OpenAPI tag inheritance](#apitag--openapi-tag-inheritance)
   - [@ApiDescription — model-driven OpenAPI descriptions](#apidescription--model-driven-openapi-descriptions)
@@ -75,16 +77,24 @@ repositories {
 ```
 
 ```kotlin
-// shared module (contracts live here — KMP: JVM + Android)
+// shared module (contracts live here — KMP: JVM + Android + iOS + JS/Wasm)
 implementation("io.github.hayatoyagi:ktor-typed-endpoint-core:<version>")
 
 // server module (route registration + OpenAPI)
 implementation("io.github.hayatoyagi:ktor-typed-endpoint-ktor-server:<version>")
+
+// client module (generated extension functions runtime)
+implementation("io.github.hayatoyagi:ktor-typed-endpoint-ktor-client:<version>")
+
+// KSP processor (generates suspend fun HttpClient.contractName(...) per contract)
+ksp("io.github.hayatoyagi:ktor-typed-endpoint-ktor-client-ksp:<version>")
 ```
 
 ## Quick Start
 
-### 1. Define your resources
+### Server
+
+#### 1. Define your resources
 
 ```kotlin
 @Serializable
@@ -101,7 +111,7 @@ class ApiRoutes {
 }
 ```
 
-### 2. Define contracts
+#### 2. Define contracts
 
 ```kotlin
 object GetBooks : GetEndpointContract<ApiRoutes.Books, BookListResponse>()
@@ -115,7 +125,7 @@ object PutBook : PutEndpointContract<ApiRoutes.Books.ById, UpdateBookRequest, Bo
 object PatchBook : PatchEndpointContract<ApiRoutes.Books.ById, PatchBookRequest, BookResponse>()
 ```
 
-### 3. Register routes
+#### 3. Register routes
 
 ```kotlin
 fun Route.bookRoutes() {
@@ -138,6 +148,45 @@ fun Route.bookRoutes() {
 ```
 
 Route registration, request deserialization, response serialization, and OpenAPI documentation are all handled automatically.
+
+### Client (KSP)
+
+The KSP processor reads every `EndpointContract` object in the module and generates a `suspend fun HttpClient.contractName(...)` extension function. Path and query parameters from the `@Resource` class are flattened into individual arguments — no manual `Resource` construction needed.
+
+Given the contracts above, the processor generates:
+
+```kotlin
+suspend fun HttpClient.getBooks(): BookListResponse
+suspend fun HttpClient.getBookById(id: String): BookResponse
+suspend fun HttpClient.postBook(body: CreateBookRequest): BookResponse
+suspend fun HttpClient.putBook(id: String, body: UpdateBookRequest): BookResponse
+```
+
+Use them directly — only the contract needs to be imported:
+
+```kotlin
+val client = HttpClient(CIO) {
+    install(Resources)
+    install(ContentNegotiation) { json() }
+    defaultRequest { url("https://api.example.com") }
+}
+
+val book = client.getBookById(id = "42")
+val created = client.postBook(body = CreateBookRequest(title = "Kotlin in Action", authorId = "1"))
+```
+
+For KMP modules, apply the processor via `kspCommonMainMetadata` and add the generated source directory:
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    kspCommonMainMetadata("io.github.hayatoyagi:ktor-typed-endpoint-ktor-client-ksp:<version>")
+}
+
+kotlin.sourceSets.commonMain {
+    kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+}
+```
 
 ## Features
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,3 +6,12 @@ plugins {
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.mavenPublish) apply false
 }
+
+// Skip signing when no signing key is configured (e.g. local development or publishToMavenLocal)
+subprojects {
+    afterEvaluate {
+        extensions.findByType<org.gradle.plugins.signing.SigningExtension>()?.apply {
+            isRequired = providers.gradleProperty("signingInMemoryKey").isPresent
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,9 +7,13 @@ android-minSdk = "24"
 logback = "1.5.29"
 kotlinx-serialization = "1.10.0"
 vanniktech-publish = "0.31.0"
+ksp = "2.2.21-2.0.5"
 
 [libraries]
 ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-resources = { module = "io.ktor:ktor-client-resources", version.ref = "ktor" }
+ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 ktor-server-resources = { module = "io.ktor:ktor-server-resources", version.ref = "ktor" }
@@ -28,3 +32,4 @@ kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", versio
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktech-publish" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ ksp = "2.2.21-2.0.5"
 [libraries]
 ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-resources = { module = "io.ktor:ktor-client-resources", version.ref = "ktor" }
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ android-minSdk = "24"
 logback = "1.5.29"
 kotlinx-serialization = "1.10.0"
 vanniktech-publish = "0.31.0"
-ksp = "2.2.21-2.0.5"
+ksp = "2.3.6"
 
 [libraries]
 ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }

--- a/ktor-client-ksp/build.gradle.kts
+++ b/ktor-client-ksp/build.gradle.kts
@@ -1,0 +1,44 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
+plugins {
+    alias(libs.plugins.kotlinJvm)
+    alias(libs.plugins.mavenPublish)
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    compileOnly(libs.ksp.api)
+    implementation(project(":ktor-client"))
+}
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    signAllPublications()
+    coordinates("io.github.hayatoyagi", "ktor-typed-endpoint-ktor-client-ksp", project.version.toString())
+    pom {
+        name.set("ktor-typed-endpoint-ktor-client-ksp")
+        description.set("KSP processor that generates type-safe HttpClient extension functions from ktor-typed-endpoint contracts.")
+        url.set("https://github.com/HayatoYagi/ktor-typed-endpoint")
+        licenses {
+            license {
+                name.set("Apache-2.0")
+                url.set("https://opensource.org/licenses/Apache-2.0")
+            }
+        }
+        developers {
+            developer {
+                id.set("HayatoYagi")
+                name.set("Hayato Yagi")
+                url.set("https://github.com/HayatoYagi")
+            }
+        }
+        scm {
+            url.set("https://github.com/HayatoYagi/ktor-typed-endpoint")
+            connection.set("scm:git:git://github.com/HayatoYagi/ktor-typed-endpoint.git")
+            developerConnection.set("scm:git:ssh://git@github.com/HayatoYagi/ktor-typed-endpoint.git")
+        }
+    }
+}

--- a/ktor-client-ksp/build.gradle.kts
+++ b/ktor-client-ksp/build.gradle.kts
@@ -11,7 +11,7 @@ kotlin {
 
 dependencies {
     compileOnly(libs.ksp.api)
-    implementation(project(":ktor-client"))
+    compileOnly(project(":ktor-client"))
 }
 
 mavenPublishing {

--- a/ktor-client-ksp/src/main/kotlin/io/github/hayatoyagi/ktortyped/ksp/ClientFunctionProcessor.kt
+++ b/ktor-client-ksp/src/main/kotlin/io/github/hayatoyagi/ktortyped/ksp/ClientFunctionProcessor.kt
@@ -1,0 +1,220 @@
+package io.github.hayatoyagi.ktortyped.ksp
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSValueParameter
+
+private val ENDPOINT_CONTRACT_TYPES = mapOf(
+    "io.github.hayatoyagi.ktortyped.GetEndpointContract" to ContractKind.GET,
+    "io.github.hayatoyagi.ktortyped.PostEndpointContract" to ContractKind.POST,
+    "io.github.hayatoyagi.ktortyped.PutEndpointContract" to ContractKind.PUT,
+    "io.github.hayatoyagi.ktortyped.PatchEndpointContract" to ContractKind.PATCH,
+    "io.github.hayatoyagi.ktortyped.DeleteEndpointContract" to ContractKind.DELETE,
+)
+
+private enum class ContractKind(val hasBody: Boolean) {
+    GET(false), POST(true), PUT(true), PATCH(true), DELETE(false),
+}
+
+internal class ClientFunctionProcessor(
+    private val codeGenerator: CodeGenerator,
+    private val logger: KSPLogger,
+) : SymbolProcessor {
+
+    private var invocationCount = 0
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        // KSP 2.x calls process() in multiple rounds; only run on the first invocation
+        if (invocationCount++ > 0) return emptyList()
+        data class ContractInfo(
+            val obj: KSClassDeclaration,
+            val superType: KSType,
+            val kind: ContractKind,
+        )
+
+        val contracts = resolver.getAllFiles()
+            .flatMap { it.declarations }
+            .filterIsInstance<KSClassDeclaration>()
+            .filter { it.classKind == ClassKind.OBJECT }
+            .mapNotNull { obj ->
+                val matchingSuperType = obj.superTypes
+                    .map { it.resolve() }
+                    .firstOrNull { st ->
+                        st.declaration.qualifiedName?.asString() in ENDPOINT_CONTRACT_TYPES
+                    } ?: return@mapNotNull null
+                val kind = ENDPOINT_CONTRACT_TYPES[matchingSuperType.declaration.qualifiedName?.asString()]!!
+                ContractInfo(obj, matchingSuperType, kind)
+            }
+            .toList()
+
+        if (contracts.isEmpty()) return emptyList()
+
+        contracts.groupBy { it.obj.packageName.asString() }.forEach { (pkg, group) ->
+            generateFile(pkg, group.map { Triple(it.obj, it.superType, it.kind) })
+        }
+
+        return emptyList()
+    }
+
+    private fun generateFile(
+        packageName: String,
+        contracts: List<Triple<KSClassDeclaration, KSType, ContractKind>>,
+    ) {
+        val sourceFiles = contracts.mapNotNull { (obj, _, _) -> obj.containingFile }
+        val file = codeGenerator.createNewFile(
+            Dependencies(false, *sourceFiles.toTypedArray()),
+            packageName,
+            "GeneratedClientFunctions",
+        )
+
+        val sb = StringBuilder()
+        sb.appendLine("@file:Suppress(\"unused\")")
+        sb.appendLine()
+        sb.appendLine("package $packageName")
+        sb.appendLine()
+        sb.appendLine("import io.ktor.client.HttpClient")
+        sb.appendLine("import io.github.hayatoyagi.ktortyped.client.request")
+        sb.appendLine()
+
+        contracts.forEach { (obj, superType, kind) ->
+            generateFunction(obj, superType, kind, sb)
+        }
+
+        file.use { it.write(sb.toString().toByteArray()) }
+    }
+
+    private fun generateFunction(
+        obj: KSClassDeclaration,
+        superType: KSType,
+        kind: ContractKind,
+        sb: StringBuilder,
+    ) {
+        val contractName = obj.simpleName.asString()
+        val functionName = contractName.replaceFirstChar { it.lowercaseChar() }
+        val typeArgs = superType.arguments
+
+        val resourceType = typeArgs[0].type?.resolve() ?: run {
+            logger.error("Cannot resolve Resource type for $contractName", obj)
+            return
+        }
+        val resourceClass = resourceType.declaration as? KSClassDeclaration ?: run {
+            logger.error("Resource type is not a class for $contractName", obj)
+            return
+        }
+        val responseType = typeArgs.last().type?.resolve() ?: run {
+            logger.error("Cannot resolve Response type for $contractName", obj)
+            return
+        }
+
+        val dataParams = collectDataParams(resourceClass)
+        val paramList = mutableListOf<String>()
+        dataParams.forEach { param ->
+            paramList.add("${param.name}: ${param.typeFqn}")
+        }
+
+        if (kind.hasBody) {
+            val requestType = typeArgs[1].type?.resolve() ?: run {
+                logger.error("Cannot resolve Request type for $contractName", obj)
+                return
+            }
+            paramList.add("body: ${requestType.toFqnString()}")
+        }
+
+        val paramsStr = if (paramList.isEmpty()) "" else "\n    ${paramList.joinToString(",\n    ")},\n"
+        val responseFqn = responseType.toFqnString()
+        val contractFqn = obj.qualifiedName?.asString()
+        val resourceExpr = buildResourceExpr(resourceClass, dataParams)
+
+        sb.appendLine("suspend fun HttpClient.$functionName($paramsStr): $responseFqn =")
+        if (kind.hasBody) {
+            sb.appendLine("    request($contractFqn, $resourceExpr, body)")
+        } else {
+            sb.appendLine("    request($contractFqn, $resourceExpr)")
+        }
+        sb.appendLine()
+    }
+
+    private data class DataParam(val name: String, val typeFqn: String)
+
+    /**
+     * Recursively collects non-parent constructor parameters from [resourceClass] and its parent chain.
+     * Parameters named "parent" with a default value are skipped (Ktor resource hierarchy boilerplate).
+     * Parameters named "parent" without a default value are resolved recursively.
+     */
+    private fun collectDataParams(resourceClass: KSClassDeclaration): List<DataParam> {
+        val constructor = resourceClass.primaryConstructor ?: return emptyList()
+        val result = mutableListOf<DataParam>()
+        for (param in constructor.parameters) {
+            if (param.name?.asString() == "parent") {
+                if (!param.hasDefault) {
+                    val parentClass = param.type.resolve().declaration as? KSClassDeclaration
+                    if (parentClass != null) {
+                        result.addAll(0, collectDataParams(parentClass))
+                    }
+                }
+                // parent with default → skip
+            } else {
+                result.add(DataParam(param.name!!.asString(), param.type.resolve().toFqnString()))
+            }
+        }
+        return result
+    }
+
+    /**
+     * Builds the constructor call expression for [resourceClass], filling in data params by name
+     * and reconstructing parent params recursively when they lack default values.
+     */
+    private fun buildResourceExpr(
+        resourceClass: KSClassDeclaration,
+        dataParams: List<DataParam>,
+    ): String {
+        val fqn = resourceClass.qualifiedName?.asString()
+        val constructor = resourceClass.primaryConstructor ?: return "$fqn()"
+        val dataParamNames = dataParams.map { it.name }.toSet()
+
+        val args = mutableListOf<String>()
+        for (param in constructor.parameters) {
+            val name = param.name?.asString() ?: continue
+            when {
+                name == "parent" && param.hasDefault -> { /* omit — use default */ }
+                name == "parent" && !param.hasDefault -> {
+                    val parentClass = param.type.resolve().declaration as? KSClassDeclaration
+                    if (parentClass != null) {
+                        // collect only the params that belong to the parent subtree
+                        val parentDataParams = collectDataParams(parentClass)
+                            .filter { it.name in dataParamNames }
+                        args.add("parent = ${buildResourceExpr(parentClass, parentDataParams)}")
+                    }
+                }
+                else -> args.add("$name = $name")
+            }
+        }
+
+        return if (args.isEmpty()) "$fqn()" else "$fqn(${args.joinToString(", ")})"
+    }
+
+    private fun KSType.toFqnString(): String {
+        val base = declaration.qualifiedName?.asString() ?: declaration.simpleName.asString()
+        val typeArgStr = if (arguments.isNotEmpty()) {
+            "<${arguments.joinToString(", ") { arg ->
+                arg.type?.resolve()?.toFqnString() ?: "*"
+            }}>"
+        } else {
+            ""
+        }
+        val nullMark = if (isMarkedNullable) "?" else ""
+        return "$base$typeArgStr$nullMark"
+    }
+
+    private fun KSValueParameter.toParamString(): String {
+        val name = name?.asString() ?: "_"
+        return "$name: ${type.resolve().toFqnString()}"
+    }
+}

--- a/ktor-client-ksp/src/main/kotlin/io/github/hayatoyagi/ktortyped/ksp/ClientFunctionProcessor.kt
+++ b/ktor-client-ksp/src/main/kotlin/io/github/hayatoyagi/ktortyped/ksp/ClientFunctionProcessor.kt
@@ -69,7 +69,7 @@ internal class ClientFunctionProcessor(
     ) {
         val sourceFiles = contracts.mapNotNull { (obj, _, _) -> obj.containingFile }
         val file = codeGenerator.createNewFile(
-            Dependencies(false, *sourceFiles.toTypedArray()),
+            Dependencies(aggregating = true, *sourceFiles.toTypedArray()),
             packageName,
             "GeneratedClientFunctions",
         )
@@ -213,8 +213,4 @@ internal class ClientFunctionProcessor(
         return "$base$typeArgStr$nullMark"
     }
 
-    private fun KSValueParameter.toParamString(): String {
-        val name = name?.asString() ?: "_"
-        return "$name: ${type.resolve().toFqnString()}"
-    }
 }

--- a/ktor-client-ksp/src/main/kotlin/io/github/hayatoyagi/ktortyped/ksp/ClientFunctionProcessor.kt
+++ b/ktor-client-ksp/src/main/kotlin/io/github/hayatoyagi/ktortyped/ksp/ClientFunctionProcessor.kt
@@ -149,8 +149,8 @@ internal class ClientFunctionProcessor(
 
     /**
      * Recursively collects non-parent constructor parameters from [resourceClass] and its parent chain.
-     * Parameters named "parent" with a default value are skipped (Ktor resource hierarchy boilerplate).
-     * Parameters named "parent" without a default value are resolved recursively.
+     * Always recurses into the parent type. A parent class is treated as boilerplate and skipped only
+     * when it has no non-parent constructor params (e.g., a top-level container like ApiRoutes).
      * Parameters with a default value are marked as optional.
      */
     private fun collectDataParams(resourceClass: KSClassDeclaration): List<DataParam> {
@@ -158,13 +158,14 @@ internal class ClientFunctionProcessor(
         val result = mutableListOf<DataParam>()
         for (param in constructor.parameters) {
             if (param.name?.asString() == "parent") {
-                if (!param.hasDefault) {
-                    val parentClass = param.type.resolve().declaration as? KSClassDeclaration
-                    if (parentClass != null) {
-                        result.addAll(0, collectDataParams(parentClass))
+                val parentClass = param.type.resolve().declaration as? KSClassDeclaration
+                if (parentClass != null) {
+                    val parentParams = collectDataParams(parentClass)
+                    if (parentParams.isNotEmpty()) {
+                        result.addAll(0, parentParams)
                     }
+                    // parentParams empty → parent is boilerplate (no meaningful params) → skip
                 }
-                // parent with default → skip
             } else {
                 result.add(
                     DataParam(

--- a/ktor-client-ksp/src/main/kotlin/io/github/hayatoyagi/ktortyped/ksp/ClientFunctionProcessor.kt
+++ b/ktor-client-ksp/src/main/kotlin/io/github/hayatoyagi/ktortyped/ksp/ClientFunctionProcessor.kt
@@ -116,7 +116,8 @@ internal class ClientFunctionProcessor(
         val paramList = mutableListOf<String>()
         dataParams.forEach { param ->
             if (param.isOptional) {
-                paramList.add("${param.name}: ${param.typeFqn}? = null")
+                val nullableFqn = if (param.typeFqn.endsWith("?")) param.typeFqn else "${param.typeFqn}?"
+                paramList.add("${param.name}: $nullableFqn = null")
             } else {
                 paramList.add("${param.name}: ${param.typeFqn}")
             }

--- a/ktor-client-ksp/src/main/kotlin/io/github/hayatoyagi/ktortyped/ksp/ClientFunctionProcessor.kt
+++ b/ktor-client-ksp/src/main/kotlin/io/github/hayatoyagi/ktortyped/ksp/ClientFunctionProcessor.kt
@@ -227,13 +227,15 @@ internal class ClientFunctionProcessor(
         for (param in constructor.parameters) {
             val name = param.name?.asString() ?: continue
             when {
-                name == "parent" && param.hasDefault -> { /* omit — use default */ }
-                name == "parent" && !param.hasDefault -> {
+                name == "parent" -> {
                     val parentClass = param.type.resolve().declaration as? KSClassDeclaration
                     if (parentClass != null) {
                         val parentDataParams = collectDataParams(parentClass)
                             .filter { it.name in dataParamNames }
-                        args.add("parent = ${buildResourceExpr(parentClass, parentDataParams)}")
+                        if (parentDataParams.isNotEmpty()) {
+                            args.add("parent = ${buildResourceExpr(parentClass, parentDataParams)}")
+                        }
+                        // parentDataParams empty → omit, use default (or no-arg constructor)
                     }
                 }
                 name in dataParamNames -> args.add("$name = $name")

--- a/ktor-client-ksp/src/main/kotlin/io/github/hayatoyagi/ktortyped/ksp/ClientFunctionProcessor.kt
+++ b/ktor-client-ksp/src/main/kotlin/io/github/hayatoyagi/ktortyped/ksp/ClientFunctionProcessor.kt
@@ -9,7 +9,6 @@ import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
-import com.google.devtools.ksp.symbol.KSValueParameter
 
 private val ENDPOINT_CONTRACT_TYPES = mapOf(
     "io.github.hayatoyagi.ktortyped.GetEndpointContract" to ContractKind.GET,
@@ -116,7 +115,11 @@ internal class ClientFunctionProcessor(
         val dataParams = collectDataParams(resourceClass)
         val paramList = mutableListOf<String>()
         dataParams.forEach { param ->
-            paramList.add("${param.name}: ${param.typeFqn}")
+            if (param.isOptional) {
+                paramList.add("${param.name}: ${param.typeFqn}? = null")
+            } else {
+                paramList.add("${param.name}: ${param.typeFqn}")
+            }
         }
 
         if (kind.hasBody) {
@@ -130,7 +133,7 @@ internal class ClientFunctionProcessor(
         val paramsStr = if (paramList.isEmpty()) "" else "\n    ${paramList.joinToString(",\n    ")},\n"
         val responseFqn = responseType.toFqnString()
         val contractFqn = obj.qualifiedName?.asString()
-        val resourceExpr = buildResourceExpr(resourceClass, dataParams)
+        val resourceExpr = buildConditionalResourceExpr(resourceClass, dataParams)
 
         sb.appendLine("suspend fun HttpClient.$functionName($paramsStr): $responseFqn =")
         if (kind.hasBody) {
@@ -141,12 +144,13 @@ internal class ClientFunctionProcessor(
         sb.appendLine()
     }
 
-    private data class DataParam(val name: String, val typeFqn: String)
+    private data class DataParam(val name: String, val typeFqn: String, val isOptional: Boolean)
 
     /**
      * Recursively collects non-parent constructor parameters from [resourceClass] and its parent chain.
      * Parameters named "parent" with a default value are skipped (Ktor resource hierarchy boilerplate).
      * Parameters named "parent" without a default value are resolved recursively.
+     * Parameters with a default value are marked as optional.
      */
     private fun collectDataParams(resourceClass: KSClassDeclaration): List<DataParam> {
         val constructor = resourceClass.primaryConstructor ?: return emptyList()
@@ -161,15 +165,53 @@ internal class ClientFunctionProcessor(
                 }
                 // parent with default → skip
             } else {
-                result.add(DataParam(param.name!!.asString(), param.type.resolve().toFqnString()))
+                result.add(
+                    DataParam(
+                        name = param.name!!.asString(),
+                        typeFqn = param.type.resolve().toFqnString(),
+                        isOptional = param.hasDefault,
+                    ),
+                )
             }
         }
         return result
     }
 
     /**
-     * Builds the constructor call expression for [resourceClass], filling in data params by name
-     * and reconstructing parent params recursively when they lack default values.
+     * Builds the resource construction expression, generating a `when` expression when optional
+     * parameters are present so each branch omits null params and lets the Resource use its defaults.
+     */
+    private fun buildConditionalResourceExpr(
+        resourceClass: KSClassDeclaration,
+        dataParams: List<DataParam>,
+    ): String {
+        val optionalParams = dataParams.filter { it.isOptional }
+        if (optionalParams.isEmpty()) {
+            return buildResourceExpr(resourceClass, dataParams)
+        }
+
+        val sb = StringBuilder()
+        sb.appendLine("when {")
+        val n = optionalParams.size
+        // Iterate from all-present (2^n - 1) down to none-present (0)
+        for (mask in ((1 shl n) - 1) downTo 0) {
+            val presentOptionals = optionalParams.filterIndexed { i, _ -> (mask shr i) and 1 == 1 }
+            val paramsForCall = dataParams.filter { !it.isOptional || it in presentOptionals }
+            val resourceExpr = buildResourceExpr(resourceClass, paramsForCall)
+            if (mask == 0) {
+                sb.appendLine("        else -> $resourceExpr")
+            } else {
+                val condition = presentOptionals.joinToString(" && ") { "${it.name} != null" }
+                sb.appendLine("        $condition -> $resourceExpr")
+            }
+        }
+        sb.append("    }")
+        return sb.toString()
+    }
+
+    /**
+     * Builds a single constructor call expression for [resourceClass] using only the params in [dataParams].
+     * Params not present in [dataParams] are omitted, allowing the Resource to use its default values.
      */
     private fun buildResourceExpr(
         resourceClass: KSClassDeclaration,
@@ -187,13 +229,13 @@ internal class ClientFunctionProcessor(
                 name == "parent" && !param.hasDefault -> {
                     val parentClass = param.type.resolve().declaration as? KSClassDeclaration
                     if (parentClass != null) {
-                        // collect only the params that belong to the parent subtree
                         val parentDataParams = collectDataParams(parentClass)
                             .filter { it.name in dataParamNames }
                         args.add("parent = ${buildResourceExpr(parentClass, parentDataParams)}")
                     }
                 }
-                else -> args.add("$name = $name")
+                name in dataParamNames -> args.add("$name = $name")
+                // else: omit — Resource uses its default value
             }
         }
 
@@ -212,5 +254,4 @@ internal class ClientFunctionProcessor(
         val nullMark = if (isMarkedNullable) "?" else ""
         return "$base$typeArgStr$nullMark"
     }
-
 }

--- a/ktor-client-ksp/src/main/kotlin/io/github/hayatoyagi/ktortyped/ksp/ClientFunctionProcessorProvider.kt
+++ b/ktor-client-ksp/src/main/kotlin/io/github/hayatoyagi/ktortyped/ksp/ClientFunctionProcessorProvider.kt
@@ -1,0 +1,10 @@
+package io.github.hayatoyagi.ktortyped.ksp
+
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+
+class ClientFunctionProcessorProvider : SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
+        ClientFunctionProcessor(environment.codeGenerator, environment.logger)
+}

--- a/ktor-client-ksp/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/ktor-client-ksp/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+io.github.hayatoyagi.ktortyped.ksp.ClientFunctionProcessorProvider

--- a/ktor-client/build.gradle.kts
+++ b/ktor-client/build.gradle.kts
@@ -1,0 +1,87 @@
+import com.vanniktech.maven.publish.SonatypeHost
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.mavenPublish)
+}
+
+kotlin {
+    jvm()
+    androidTarget {
+        publishLibraryVariants("release")
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
+    iosArm64()
+    iosX64()
+    iosSimulatorArm64()
+    macosArm64()
+    macosX64()
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+    watchosArm32()
+    watchosArm64()
+    watchosX64()
+    watchosSimulatorArm64()
+    watchosDeviceArm64()
+    linuxArm64()
+    linuxX64()
+    mingwX64()
+    js { browser(); nodejs() }
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs { browser() }
+
+    sourceSets {
+        commonMain.dependencies {
+            api(project(":core"))
+            api(libs.ktor.client.core)
+            api(libs.ktor.client.resources)
+        }
+    }
+}
+
+android {
+    namespace = "io.github.hayatoyagi.ktortyped.client"
+    compileSdk = 36
+    defaultConfig {
+        minSdk = 21
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    signAllPublications()
+    coordinates("io.github.hayatoyagi", "ktor-typed-endpoint-ktor-client", project.version.toString())
+    pom {
+        name.set("ktor-typed-endpoint-ktor-client")
+        description.set("Type-safe HTTP client extensions for ktor-typed-endpoint contracts.")
+        url.set("https://github.com/HayatoYagi/ktor-typed-endpoint")
+        licenses {
+            license {
+                name.set("Apache-2.0")
+                url.set("https://opensource.org/licenses/Apache-2.0")
+            }
+        }
+        developers {
+            developer {
+                id.set("HayatoYagi")
+                name.set("Hayato Yagi")
+                url.set("https://github.com/HayatoYagi")
+            }
+        }
+        scm {
+            url.set("https://github.com/HayatoYagi/ktor-typed-endpoint")
+            connection.set("scm:git:git://github.com/HayatoYagi/ktor-typed-endpoint.git")
+            developerConnection.set("scm:git:ssh://git@github.com/HayatoYagi/ktor-typed-endpoint.git")
+        }
+    }
+}

--- a/ktor-client/src/commonMain/kotlin/io/github/hayatoyagi/ktortyped/client/EndpointClient.kt
+++ b/ktor-client/src/commonMain/kotlin/io/github/hayatoyagi/ktortyped/client/EndpointClient.kt
@@ -1,0 +1,61 @@
+package io.github.hayatoyagi.ktortyped.client
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.resources.delete
+import io.ktor.client.plugins.resources.get
+import io.ktor.client.plugins.resources.patch
+import io.ktor.client.plugins.resources.post
+import io.ktor.client.plugins.resources.put
+import io.ktor.client.request.setBody
+import io.github.hayatoyagi.ktortyped.DeleteEndpointContract
+import io.github.hayatoyagi.ktortyped.GetEndpointContract
+import io.github.hayatoyagi.ktortyped.PatchEndpointContract
+import io.github.hayatoyagi.ktortyped.PostEndpointContract
+import io.github.hayatoyagi.ktortyped.PutEndpointContract
+
+/**
+ * Sends a `GET` request described by [contract] for the given [resource].
+ *
+ * The response is deserialized to [Response] automatically.
+ * Intended to be called from KSP-generated client functions — use those instead of calling this directly.
+ */
+suspend inline fun <reified Resource : Any, reified Response : Any> HttpClient.request(
+    contract: GetEndpointContract<Resource, Response>,
+    resource: Resource,
+): Response = get(resource).body()
+
+/**
+ * Sends a `POST` request described by [contract] with [body] for the given [resource].
+ */
+suspend inline fun <reified Resource : Any, reified Request : Any, reified Response : Any> HttpClient.request(
+    contract: PostEndpointContract<Resource, Request, Response>,
+    resource: Resource,
+    body: Request,
+): Response = post(resource) { setBody(body) }.body()
+
+/**
+ * Sends a `PUT` request described by [contract] with [body] for the given [resource].
+ */
+suspend inline fun <reified Resource : Any, reified Request : Any, reified Response : Any> HttpClient.request(
+    contract: PutEndpointContract<Resource, Request, Response>,
+    resource: Resource,
+    body: Request,
+): Response = put(resource) { setBody(body) }.body()
+
+/**
+ * Sends a `PATCH` request described by [contract] with [body] for the given [resource].
+ */
+suspend inline fun <reified Resource : Any, reified Request : Any, reified Response : Any> HttpClient.request(
+    contract: PatchEndpointContract<Resource, Request, Response>,
+    resource: Resource,
+    body: Request,
+): Response = patch(resource) { setBody(body) }.body()
+
+/**
+ * Sends a `DELETE` request described by [contract] for the given [resource].
+ */
+suspend inline fun <reified Resource : Any, reified Response : Any> HttpClient.request(
+    contract: DeleteEndpointContract<Resource, Response>,
+    resource: Resource,
+): Response = delete(resource).body()

--- a/ktor-client/src/commonMain/kotlin/io/github/hayatoyagi/ktortyped/client/EndpointClient.kt
+++ b/ktor-client/src/commonMain/kotlin/io/github/hayatoyagi/ktortyped/client/EndpointClient.kt
@@ -21,7 +21,7 @@ import io.github.hayatoyagi.ktortyped.PutEndpointContract
  * Intended to be called from KSP-generated client functions — use those instead of calling this directly.
  */
 suspend inline fun <reified Resource : Any, reified Response : Any> HttpClient.request(
-    contract: GetEndpointContract<Resource, Response>,
+    @Suppress("UNUSED_PARAMETER") contract: GetEndpointContract<Resource, Response>,
     resource: Resource,
 ): Response = get(resource).body()
 
@@ -29,7 +29,7 @@ suspend inline fun <reified Resource : Any, reified Response : Any> HttpClient.r
  * Sends a `POST` request described by [contract] with [body] for the given [resource].
  */
 suspend inline fun <reified Resource : Any, reified Request : Any, reified Response : Any> HttpClient.request(
-    contract: PostEndpointContract<Resource, Request, Response>,
+    @Suppress("UNUSED_PARAMETER") contract: PostEndpointContract<Resource, Request, Response>,
     resource: Resource,
     body: Request,
 ): Response = post(resource) { setBody(body) }.body()
@@ -38,7 +38,7 @@ suspend inline fun <reified Resource : Any, reified Request : Any, reified Respo
  * Sends a `PUT` request described by [contract] with [body] for the given [resource].
  */
 suspend inline fun <reified Resource : Any, reified Request : Any, reified Response : Any> HttpClient.request(
-    contract: PutEndpointContract<Resource, Request, Response>,
+    @Suppress("UNUSED_PARAMETER") contract: PutEndpointContract<Resource, Request, Response>,
     resource: Resource,
     body: Request,
 ): Response = put(resource) { setBody(body) }.body()
@@ -47,7 +47,7 @@ suspend inline fun <reified Resource : Any, reified Request : Any, reified Respo
  * Sends a `PATCH` request described by [contract] with [body] for the given [resource].
  */
 suspend inline fun <reified Resource : Any, reified Request : Any, reified Response : Any> HttpClient.request(
-    contract: PatchEndpointContract<Resource, Request, Response>,
+    @Suppress("UNUSED_PARAMETER") contract: PatchEndpointContract<Resource, Request, Response>,
     resource: Resource,
     body: Request,
 ): Response = patch(resource) { setBody(body) }.body()
@@ -56,6 +56,6 @@ suspend inline fun <reified Resource : Any, reified Request : Any, reified Respo
  * Sends a `DELETE` request described by [contract] for the given [resource].
  */
 suspend inline fun <reified Resource : Any, reified Response : Any> HttpClient.request(
-    contract: DeleteEndpointContract<Resource, Response>,
+    @Suppress("UNUSED_PARAMETER") contract: DeleteEndpointContract<Resource, Response>,
     resource: Resource,
 ): Response = delete(resource).body()

--- a/ktor-server/build.gradle.kts
+++ b/ktor-server/build.gradle.kts
@@ -20,6 +20,8 @@ dependencies {
     testImplementation(libs.ktor.server.content.negotiation)
     testImplementation(libs.ktor.serialization.kotlinx.json)
     testImplementation(libs.kotlinx.serialization.json)
+    testImplementation(libs.ktor.client.resources)
+    testImplementation(libs.ktor.client.content.negotiation)
 }
 
 tasks.withType<Test>().configureEach {

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.ktor)
+    alias(libs.plugins.ksp)
     application
 }
 
@@ -16,14 +17,19 @@ application {
 dependencies {
     implementation(project(":core"))
     implementation(project(":ktor-server"))
+    implementation(project(":ktor-client"))
     implementation(libs.ktor.server.core)
     implementation(libs.ktor.server.netty)
     implementation(libs.ktor.server.resources)
     implementation(libs.ktor.server.content.negotiation)
     implementation(libs.ktor.server.routing.openapi)
     implementation(libs.ktor.server.swagger)
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.cio)
+    implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.kotlinx.serialization.json)
+    ksp(project(":ktor-client-ksp"))
 }
 
 ktor {

--- a/sample/src/main/kotlin/io/github/hayatoyagi/ktortyped/sample/SampleClient.kt
+++ b/sample/src/main/kotlin/io/github/hayatoyagi/ktortyped/sample/SampleClient.kt
@@ -1,0 +1,48 @@
+package io.github.hayatoyagi.ktortyped.sample
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.plugins.resources.Resources
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+/**
+ * Demonstrates using KSP-generated client extension functions.
+ *
+ * The KSP processor reads the contract objects in this module and generates:
+ *
+ *   suspend fun HttpClient.getBooks(): BookListResponse
+ *   suspend fun HttpClient.getBookById(id: String): BookResponse
+ *   suspend fun HttpClient.postBook(body: CreateBookRequest): BookResponse
+ *   ... and so on for every contract
+ *
+ * Callers only import the contract — no manual Resource construction needed.
+ */
+suspend fun runSampleClient() {
+    val client = HttpClient(CIO) {
+        install(Resources)
+        install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        defaultRequest {
+            url("http://localhost:8080")
+            contentType(ContentType.Application.Json)
+        }
+    }
+
+    client.use {
+        // GET /v1/books
+        val books = it.getBooks()
+        println("Books: $books")
+
+        // POST /v1/books
+        val created = it.postBook(body = CreateBookRequest(title = "Kotlin in Action", authorId = "1"))
+        println("Created: $created")
+
+        // GET /v1/books/{id}
+        val book = it.getBookById(id = created.id)
+        println("Fetched: $book")
+    }
+}

--- a/sample/src/main/kotlin/io/github/hayatoyagi/ktortyped/sample/SampleRoutes.kt
+++ b/sample/src/main/kotlin/io/github/hayatoyagi/ktortyped/sample/SampleRoutes.kt
@@ -11,7 +11,7 @@ class SampleRoutes {
     @ApiTag("books")
     @Serializable
     @Resource("books")
-    class Books(val parent: SampleRoutes = SampleRoutes()) {
+    class Books(val parent: SampleRoutes = SampleRoutes(), val sort: String? = null) {
 
         @Serializable
         @Resource("{id}")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,4 +17,6 @@ rootProject.name = "ktor-typed-endpoint"
 
 include(":core")
 include(":ktor-server")
+include(":ktor-client")
+include(":ktor-client-ksp")
 include(":sample")


### PR DESCRIPTION
## Summary

- **`:ktor-client`** — KMP runtime module with `HttpClient.request(contract, resource)` overloads for GET/POST/PUT/PATCH/DELETE contracts
- **`:ktor-client-ksp`** — KSP processor that generates `suspend fun HttpClient.contractName(flatParams): Response` extension functions from `EndpointContract` objects
- Consumers only need to import the contract — no manual `Resource` class construction required

## Generated code example

Given a contract:
```kotlin
object GetPerformanceHistoriesById : GetEndpointContract<ApiRoutes.PerformanceHistories.ById, PerformanceHistoryItemResponse>
```

The processor generates:
```kotlin
suspend fun HttpClient.getPerformanceHistoriesById(
    id: PerformanceHistoryId,
): PerformanceHistoryItemResponse =
    request(GetPerformanceHistoriesById, ApiRoutes.PerformanceHistories.ById(id = id))
```

Path/query params from the Resource constructor are flattened as individual function arguments. POST/PUT/PATCH contracts get an additional `body` parameter.

## Test plan

- [ ] `:ktor-client:compileKotlinJvm` passes
- [ ] `:ktor-client-ksp:compileKotlin` passes
- [ ] KSP processor generates correct `GeneratedClientFunctions.kt` per package in a consumer module

🤖 Generated with [Claude Code](https://claude.com/claude-code)