### PR TITLE
chore: update Kotlin, Ktor, AGP, and other dependencies to latest stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Type-safe HTTP endpoint contracts for Ktor — bind routing, request/response ty
 
 - [Overview](#overview)
 - [Motivation](#motivation)
+- [Requirements](#requirements)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Features](#features)
@@ -64,6 +65,12 @@ endpoint(PostBook) { _, request ->
     createBook(request)
 }
 ```
+
+## Requirements
+
+- Kotlin 2.4.10+ — earlier compilers may fail to read the published Kotlin/Native, JS, and Wasm klibs for non-JVM/Android targets.
+- Ktor 3.5.x — `ktor-typed-endpoint-ktor-server`'s public API is built against Ktor 3.5.2; other Ktor 3.x versions should generally work, but matching your app's Ktor version to the same 3.5.x line is recommended.
+- Android: `compileSdk` 36, `minSdk` 21+.
 
 ## Installation
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
@@ -9,8 +8,10 @@ plugins {
 
 kotlin {
     jvm()
-    androidTarget {
-        publishLibraryVariants("release")
+    android {
+        namespace = "io.github.hayatoyagi.ktortyped"
+        compileSdk = 36
+        minSdk = 21
     }
     iosArm64()
     iosX64()
@@ -43,16 +44,8 @@ kotlin {
     }
 }
 
-android {
-    namespace = "io.github.hayatoyagi.ktortyped"
-    compileSdk = 36
-    defaultConfig {
-        minSdk = 21
-    }
-}
-
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
     signAllPublications()
     coordinates("io.github.hayatoyagi", "ktor-typed-endpoint-core", project.version.toString())
     pom {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-kotlin = "2.3.10"
-ktor = "3.4.0"
-agp = "8.13.2"
+kotlin = "2.4.10"
+ktor = "3.5.2"
+agp = "9.3.1"
 android-compileSdk = "36"
 android-minSdk = "24"
-logback = "1.5.29"
-kotlinx-serialization = "1.10.0"
-vanniktech-publish = "0.31.0"
+logback = "1.6.3"
+kotlinx-serialization = "1.11.0"
+vanniktech-publish = "0.37.0"
 
 [libraries]
 ktor-http = { module = "io.ktor:ktor-http", version.ref = "ktor" }
@@ -25,6 +25,6 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-androidLibrary = { id = "com.android.library", version.ref = "agp" }
+androidLibrary = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 ktor = { id = "io.ktor.plugin", version.ref = "ktor" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "vanniktech-publish" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/ktor-server/build.gradle.kts
+++ b/ktor-server/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
-
 plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.kotlinSerialization)
@@ -27,7 +25,7 @@ tasks.withType<Test>().configureEach {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
     signAllPublications()
     coordinates("io.github.hayatoyagi", "ktor-typed-endpoint-ktor-server", project.version.toString())
     pom {


### PR DESCRIPTION
## Summary
- Bumps Kotlin 2.3.10→2.4.10, Ktor 3.4.0→3.5.2, AGP 8.13.2→9.3.1, Gradle 8.14.3→9.7.0, Logback 1.5.29→1.6.3, kotlinx-serialization 1.10.0→1.11.0, vanniktech-publish 0.31.0→0.37.0
- Migrates `core` from `com.android.library` to `com.android.kotlin.multiplatform.library`, since AGP 9.0 dropped compatibility between `com.android.library` and the Kotlin Multiplatform plugin. The `android {}` config now lives inside `kotlin { android { ... } }` instead of a separate top-level block.
- Updates `publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)` → `publishToMavenCentral()` in `core` and `ktor-server`, since vanniktech-publish 0.34.0 removed the `SonatypeHost` API (Central Portal publishing is now the default).

## Test plan
- [x] `./gradlew build` passes locally — all 115 tasks succeed, including `core`, `ktor-server`, and `sample` module tests
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)